### PR TITLE
Add CORS policy to allow requests from Netlify app

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,12 @@ loadModels();
 
 const port = vars.port || 3000;
 
-app.use(cors());
+const corsOptions = {
+  origin: 'https://from-memory-to-space.netlify.app',
+  optionsSuccessStatus: 200, // For legacy browser support
+};
+
+app.use(cors(corsOptions));
 app.use(bodyParser.json());
 
 RegisterRoutes(app);


### PR DESCRIPTION
- Updated CORS policy in server to allow requests from 'https://from-memory-to-space.netlify.app'.
- Fixed issue with blocked requests due to missing 'Access-Control-Allow-Origin' header.